### PR TITLE
Add link to player information forwarding

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,7 @@
                     <a href="http://www.minecraftforge.net">Minecraft Forge</a>. We're also able to respond to Minecraft updates quickly, so you'll never have an
                     excuse to not update.
                 </p>
-                <a href="https://docs.velocitypowered.com/en/latest/users/player-info-forwarding.html" class="waves-effect waves-light btn light-blue darken-2"><i class="material-icons left">archive</i>Learn more about Velocity's server support</a>
+                <a href="https://docs.velocitypowered.com/en/latest/users/frequently-asked-questions.html#what-server-software-is-supported-by-velocity" class="waves-effect waves-light btn light-blue darken-2"><i class="material-icons left">archive</i>Learn more about Velocity's server support</a>
             </div>
         </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -86,7 +86,7 @@
                     Velocity comes with IP forwarding that is secure by default. Simply choose a secure password and put it
                     in your server configurations. Help ward off griefers with hacked clients!
                 </p>
-                <a href="#!" class="waves-effect waves-light btn light-blue darken-2"><i class="material-icons left">archive</i>Configure your servers for more security</a>
+                <a href="https://docs.velocitypowered.com/en/latest/users/player-info-forwarding.html" class="waves-effect waves-light btn light-blue darken-2"><i class="material-icons left">archive</i>Configure your servers for more security</a>
             </div>
         </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,7 @@
                     <a href="http://www.minecraftforge.net">Minecraft Forge</a>. We're also able to respond to Minecraft updates quickly, so you'll never have an
                     excuse to not update.
                 </p>
-                <a href="#!" class="waves-effect waves-light btn light-blue darken-2"><i class="material-icons left">archive</i>Learn more about Velocity's server support</a>
+                <a href="https://docs.velocitypowered.com/en/latest/users/player-info-forwarding.html" class="waves-effect waves-light btn light-blue darken-2"><i class="material-icons left">archive</i>Learn more about Velocity's server support</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The current link for server support doesn't link anywhere and I think this is the docs page that currently best fits this button.