### PR TITLE
aquifermc.org -> papermc.io

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -77,7 +77,7 @@
                 <div class="col m7">
                     <h4>Make your server how you want it.</h4>
                     <p>
-                        Velocity comes with excellent support for <a href="https://aquifermc.org">Paper</a>, <a href="https://www.spongepowered.org">Sponge</a>, and
+                        Velocity comes with excellent support for <a href="https://papermc.io">Paper</a>, <a href="https://www.spongepowered.org">Sponge</a>, and
                         <a href="http://www.minecraftforge.net">Minecraft Forge</a>. We're also able to respond to Minecraft updates quickly, so you'll never have an
                         excuse to not update.
                     </p>


### PR DESCRIPTION
This PR fixes the incorrect URL for Paper.